### PR TITLE
Fix asynchronous error

### DIFF
--- a/errors/max_ticks_exceeded_error.test.ts
+++ b/errors/max_ticks_exceeded_error.test.ts
@@ -1,0 +1,39 @@
+import { describe, it } from "https://deno.land/std@0.197.0/testing/bdd.ts";
+import {
+  assertEquals,
+  assertInstanceOf,
+} from "https://deno.land/std@0.197.0/assert/mod.ts";
+import { MaxTicksExceededError } from "./max_ticks_exceeded_error.ts";
+
+describe("MaxTicksExceededError", () => {
+  it("should be able to instantiate", () => {
+    const error = new MaxTicksExceededError();
+
+    assertInstanceOf(error, MaxTicksExceededError);
+  });
+  it("should be able to instantiate", () => {
+    const error = new MaxTicksExceededError();
+
+    assertInstanceOf(error, MaxTicksExceededError);
+  });
+  it("should have a name", () => {
+    const error = new MaxTicksExceededError();
+
+    assertEquals(error.name, "MaxTicksExceededError");
+  });
+  it("should have a message", () => {
+    const error = new MaxTicksExceededError();
+
+    assertEquals(error.message, "");
+  });
+  it("should have a stack", () => {
+    const error = new MaxTicksExceededError();
+
+    assertEquals(typeof error.stack, "string");
+  });
+  it("should be able to specify the message", () => {
+    const error = new MaxTicksExceededError("foo");
+
+    assertEquals(error.message, "foo");
+  });
+});

--- a/errors/max_ticks_exceeded_error.ts
+++ b/errors/max_ticks_exceeded_error.ts
@@ -1,0 +1,5 @@
+import { TestStreamError } from "./test_stream_error.ts";
+
+export class MaxTicksExceededError extends TestStreamError {
+  override name = "MaxTicksExceededError";
+}

--- a/errors/mod.ts
+++ b/errors/mod.ts
@@ -1,2 +1,3 @@
+export * from "./max_ticks_exceeded_error.ts";
 export * from "./operation_not_permitted_error.ts";
 export * from "./test_stream_error.ts";

--- a/test_stream.test.ts
+++ b/test_stream.test.ts
@@ -254,6 +254,18 @@ describe("testStream", () => {
           "tickTime cannot go backwards",
         );
       });
+      it("should throws if a float value is specified", () => {
+        assertThrows(
+          () => {
+            testStream({
+              tickTime: 0.5,
+              async fn() {},
+            });
+          },
+          TypeError,
+          "tickTime should be an integer",
+        );
+      });
     });
   });
   describe("TestStreamFn", () => {

--- a/test_stream.test.ts
+++ b/test_stream.test.ts
@@ -16,7 +16,10 @@ import {
   assertThrows,
 } from "https://deno.land/std@0.197.0/assert/mod.ts";
 import { delay } from "https://deno.land/std@0.197.0/async/delay.ts";
-import { OperationNotPermittedError, TestStreamError } from "./errors/mod.ts";
+import {
+  MaxTicksExceededError,
+  OperationNotPermittedError,
+} from "./errors/mod.ts";
 import {
   testStream,
   type TestStreamHelper,
@@ -115,8 +118,8 @@ describe("testStream", () => {
                 () => {
                   return stream.pipeTo(writable);
                 },
-                TestStreamError,
-                "Too many ticks",
+                MaxTicksExceededError,
+                "Ticks exceeded",
               );
             });
 
@@ -143,8 +146,8 @@ describe("testStream", () => {
                 () => {
                   return stream.pipeTo(writable);
                 },
-                TestStreamError,
-                "Too many ticks",
+                MaxTicksExceededError,
+                "Ticks exceeded",
               );
             });
 

--- a/test_stream.ts
+++ b/test_stream.ts
@@ -9,7 +9,10 @@ import { assertEquals } from "https://deno.land/std@0.197.0/assert/assert_equals
 import { AssertionError } from "https://deno.land/std@0.197.0/assert/assertion_error.ts";
 import { FakeTime } from "https://deno.land/std@0.197.0/testing/time.ts";
 import { getLogger } from "https://deno.land/std@0.197.0/log/mod.ts";
-import { OperationNotPermittedError, TestStreamError } from "./errors/mod.ts";
+import {
+  MaxTicksExceededError,
+  OperationNotPermittedError,
+} from "./errors/mod.ts";
 
 function logger() {
   return getLogger("testStream");
@@ -598,7 +601,9 @@ function createRunnerFromFrames(
           if (++tickCount >= maxTicks) {
             logger().debug("createRunnerFromFrames(): exceeded", { id });
             controller.error(
-              new TestStreamError("Too many ticks", { cause: { maxTicks } }),
+              new MaxTicksExceededError("Ticks exceeded", {
+                cause: { maxTicks },
+              }),
             );
             done = true;
           }
@@ -708,7 +713,7 @@ function createRunnerFromStream<T>(
       if (++tickCount >= maxTicks) {
         logger().debug("createRunnerFromStream(): exceeded", { id });
         abortController.abort(
-          new TestStreamError("Too many ticks", { cause: { maxTicks } }),
+          new MaxTicksExceededError("Ticks exceeded", { cause: { maxTicks } }),
         );
         done = true;
       }

--- a/test_stream.ts
+++ b/test_stream.ts
@@ -611,9 +611,8 @@ function createRunnerFromFrames(
           break;
         }
         case "error": {
-          const error = value !== NO_VALUE ? value : "error";
-          controller.error(error);
-          addLog({ type, value: error });
+          controller.error(value);
+          addLog({ type, value });
           done = true;
           break;
         }


### PR DESCRIPTION
`TestStreamHelper.assertReadable` should match the stream transformed from `readable` and asynchronously aborted with `run`.