### PR TITLE
test: add await-before-timer test

### DIFF
--- a/test_stream.test.ts
+++ b/test_stream.test.ts
@@ -800,6 +800,33 @@ describe("testStream", () => {
           }, "terminate");
         });
       });
+      it("should match the stream that uses timer", async () => {
+        await testStream(async ({ assertReadable }) => {
+          const stream = new ReadableStream<string>({
+            async start(controller) {
+              controller.enqueue("A");
+              await delay(100);
+              controller.close();
+            },
+          });
+
+          await assertReadable(stream, "A|");
+        });
+      });
+      it("should match the stream that uses await before timer", async () => {
+        await testStream(async ({ assertReadable }) => {
+          const stream = new ReadableStream<string>({
+            async start(controller) {
+              await Promise.resolve();
+              controller.enqueue("A");
+              await delay(100);
+              controller.close();
+            },
+          });
+
+          await assertReadable(stream, "A|");
+        });
+      });
     });
     describe(".readable", () => {
       it("should returns a readable stream", async () => {


### PR DESCRIPTION
`FakeTime.restoreFor` is fixed in deno_std@0.199.0. So closes #6