### PR TITLE
feat: add `setLogger` function

### DIFF
--- a/errors/leaking_async_ops_error_test.ts
+++ b/errors/leaking_async_ops_error_test.ts
@@ -1,8 +1,8 @@
-import { describe, it } from "https://deno.land/std@0.199.0/testing/bdd.ts";
+import { describe, it } from "https://deno.land/std@0.201.0/testing/bdd.ts";
 import {
   assertEquals,
   assertInstanceOf,
-} from "https://deno.land/std@0.199.0/assert/mod.ts";
+} from "https://deno.land/std@0.201.0/assert/mod.ts";
 import { LeakingAsyncOpsError } from "./leaking_async_ops_error.ts";
 
 describe("LeakingAsyncOpsError", () => {

--- a/errors/max_ticks_exceeded_error.test.ts
+++ b/errors/max_ticks_exceeded_error.test.ts
@@ -1,8 +1,8 @@
-import { describe, it } from "https://deno.land/std@0.199.0/testing/bdd.ts";
+import { describe, it } from "https://deno.land/std@0.201.0/testing/bdd.ts";
 import {
   assertEquals,
   assertInstanceOf,
-} from "https://deno.land/std@0.199.0/assert/mod.ts";
+} from "https://deno.land/std@0.201.0/assert/mod.ts";
 import { MaxTicksExceededError } from "./max_ticks_exceeded_error.ts";
 
 describe("MaxTicksExceededError", () => {

--- a/errors/operation_not_permitted_error.test.ts
+++ b/errors/operation_not_permitted_error.test.ts
@@ -1,8 +1,8 @@
-import { describe, it } from "https://deno.land/std@0.199.0/testing/bdd.ts";
+import { describe, it } from "https://deno.land/std@0.201.0/testing/bdd.ts";
 import {
   assertEquals,
   assertInstanceOf,
-} from "https://deno.land/std@0.199.0/assert/mod.ts";
+} from "https://deno.land/std@0.201.0/assert/mod.ts";
 import { OperationNotPermittedError } from "./operation_not_permitted_error.ts";
 
 describe("OperationNotPermittedError", () => {

--- a/errors/test_stream_error.test.ts
+++ b/errors/test_stream_error.test.ts
@@ -1,8 +1,8 @@
-import { describe, it } from "https://deno.land/std@0.199.0/testing/bdd.ts";
+import { describe, it } from "https://deno.land/std@0.201.0/testing/bdd.ts";
 import {
   assertEquals,
   assertInstanceOf,
-} from "https://deno.land/std@0.199.0/assert/mod.ts";
+} from "https://deno.land/std@0.201.0/assert/mod.ts";
 import { TestStreamError } from "./test_stream_error.ts";
 
 describe("TestStreamError", () => {

--- a/examples/upper_case.test.ts
+++ b/examples/upper_case.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "https://deno.land/std@0.199.0/testing/bdd.ts";
+import { describe, it } from "https://deno.land/std@0.201.0/testing/bdd.ts";
 import { testStream } from "../test_stream.ts";
 import { UpperCase } from "./upper_case.ts";
 

--- a/test.ts
+++ b/test.ts
@@ -1,4 +1,4 @@
-import { assertExists } from "https://deno.land/std@0.199.0/assert/mod.ts";
+import { assertExists } from "https://deno.land/std@0.201.0/assert/mod.ts";
 
 const FILES = ["README.md"];
 

--- a/test_stream.test.ts
+++ b/test_stream.test.ts
@@ -27,6 +27,7 @@ import {
   OperationNotPermittedError,
 } from "./errors/mod.ts";
 import {
+  setLogger,
   testStream,
   type TestStreamHelper,
   TestStreamHelperAbort,
@@ -59,6 +60,7 @@ try {
         },
       },
     });
+    setLogger(log.getLogger("testStream"));
   }
 } catch (e: unknown) {
   if (!(e instanceof Deno.errors.PermissionDenied)) {

--- a/test_stream.test.ts
+++ b/test_stream.test.ts
@@ -2,11 +2,11 @@ import {
   beforeEach,
   describe,
   it,
-} from "https://deno.land/std@0.199.0/testing/bdd.ts";
+} from "https://deno.land/std@0.201.0/testing/bdd.ts";
 import {
   assertSpyCalls,
   spy,
-} from "https://deno.land/std@0.199.0/testing/mock.ts";
+} from "https://deno.land/std@0.201.0/testing/mock.ts";
 import {
   assert,
   assertEquals,
@@ -18,9 +18,9 @@ import {
   assertRejects,
   assertStrictEquals,
   assertThrows,
-} from "https://deno.land/std@0.199.0/assert/mod.ts";
-import * as log from "https://deno.land/std@0.199.0/log/mod.ts";
-import { delay } from "https://deno.land/std@0.199.0/async/delay.ts";
+} from "https://deno.land/std@0.201.0/assert/mod.ts";
+import * as log from "https://deno.land/std@0.201.0/log/mod.ts";
+import { delay } from "https://deno.land/std@0.201.0/async/delay.ts";
 import {
   LeakingAsyncOpsError,
   MaxTicksExceededError,

--- a/test_stream.ts
+++ b/test_stream.ts
@@ -5,10 +5,10 @@
  * @module
  */
 
-import { assertEquals } from "https://deno.land/std@0.199.0/assert/assert_equals.ts";
-import { AssertionError } from "https://deno.land/std@0.199.0/assert/assertion_error.ts";
-import { FakeTime } from "https://deno.land/std@0.199.0/testing/time.ts";
-import type { Logger } from "https://deno.land/std@0.199.0/log/logger.ts";
+import { assertEquals } from "https://deno.land/std@0.201.0/assert/assert_equals.ts";
+import { AssertionError } from "https://deno.land/std@0.201.0/assert/assertion_error.ts";
+import { FakeTime } from "https://deno.land/std@0.201.0/testing/time.ts";
+import type { Logger } from "https://deno.land/std@0.201.0/log/logger.ts";
 import {
   LeakingAsyncOpsError,
   MaxTicksExceededError,


### PR DESCRIPTION
If the version of `std/log` is different, the logger settings will not be shared and log output will not be possible.
Therefore, we added a function to set the logger instance from outside the library.